### PR TITLE
Adding flag and support for obtaining and printing server NSID [alternate implementation]

### DIFF
--- a/check_serial.py
+++ b/check_serial.py
@@ -104,7 +104,7 @@ def get_serial(zone, nshost, nsip):
         resp = send_query(zone, 'SOA', nsip)
     except socket.error as e_info:
         print("ERROR: {} {}: socket: {}".format(nshost, nsip, e_info))
-        return None
+        return None, None
     if resp is None:
         print("ERROR: No answer from {} {}".format(nshost, nsip))
     elif resp.rcode() != 0:


### PR DESCRIPTION
HI Shumon!

This is a variant of @martinberg's idea to get the NSID for each server. I'm building on @martinberg's implementation, with two major differences:

1. Using the EDNS(0) option to request the NSID from the remote server is tied to a command line option (suggested: -i) so that the output only appears when you actively request it. The thought behind that is to not "disturb" existing usage of check_serial.py. If an existing user updates the code and just continues to use it, the output should remain the same, to avoid breaking post-processing of the output (using "sed" or "awk" or whatever).

1. The NSID option is enabled in the _same_ outgoing query as the SOA request. This can be important if the server you're trying to reach is either anycasted or sits behind a load balancer (or both!). If so, two subsequent queries may end up at different servers, and one really wants to know the NSID for the same server as the serial number is reported from.

Thanks, @martinberg, for initiating this and for inspiring me.

Cheers,
/Liman